### PR TITLE
Normalize ogre path.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,9 +11,10 @@ source:
     patches:
       - use-external-libs-config.patch
       - qwt-fix.patch
+      - normalize-ogre-path.patch
 
 build:
-  number: 3
+  number: 4
   skip: true  # [not win]
   run_exports:
     - {{ pin_subpackage('gazebo', max_pin='x.x') }}

--- a/recipe/normalize-ogre-path.patch
+++ b/recipe/normalize-ogre-path.patch
@@ -1,0 +1,16 @@
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -162,12 +162,13 @@
+ FILE(TO_NATIVE_PATH "${GAZEBO_RESOURCE_PATH}" GAZEBO_RESOURCE_PATH)
+ set(GAZEBO_MODEL_DATABASE_URI http://models.gazebosim.org)
+ set(OGRE_RESOURCE_PATH ${OGRE_PLUGINDIR})
+ # Seems that OGRE_PLUGINDIR can end in a newline, which will cause problems when
+ # we pass it to the compiler later.
+ string(REPLACE "\n" "" OGRE_RESOURCE_PATH ${OGRE_RESOURCE_PATH})
++FILE(TO_NATIVE_PATH "${OGRE_RESOURCE_PATH}" OGRE_RESOURCE_PATH)
+ 
+ 
+ # Check for DRI capable Display
+ include (${gazebo_cmake_dir}/CheckDRIDisplay.cmake)
+ 
+ #####################################


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
* Normalize `OGRE` path so only backward slash is in use for `setup.bat`. Therefore, `conda` can make it relocatable.