### PR TITLE
Bump version to Gazebo 11.3.0

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,11 +11,11 @@ jobs:
       linux_64_boost_cpp1.72.0:
         CONFIG: linux_64_boost_cpp1.72.0
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
       linux_64_boost_cpp1.74.0:
         CONFIG: linux_64_boost_cpp1.74.0
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_boost_cpp1.72.0.yaml
+++ b/.ci_support/linux_64_boost_cpp1.72.0.yaml
@@ -3,7 +3,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '9'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,9 +15,9 @@ curl:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '9'
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 libcurl:
 - '7'
 libprotobuf:

--- a/.ci_support/linux_64_boost_cpp1.74.0.yaml
+++ b/.ci_support/linux_64_boost_cpp1.74.0.yaml
@@ -3,7 +3,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '9'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,9 +15,9 @@ curl:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '9'
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 libcurl:
 - '7'
 libprotobuf:

--- a/.ci_support/osx_64_boost_cpp1.72.0.yaml
+++ b/.ci_support/osx_64_boost_cpp1.72.0.yaml
@@ -7,7 +7,7 @@ bzip2:
 c_compiler:
 - clang
 c_compiler_version:
-- '10'
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -17,7 +17,7 @@ curl:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '10'
+- '11'
 libcurl:
 - '7'
 libprotobuf:

--- a/.ci_support/osx_64_boost_cpp1.74.0.yaml
+++ b/.ci_support/osx_64_boost_cpp1.74.0.yaml
@@ -7,7 +7,7 @@ bzip2:
 c_compiler:
 - clang
 c_compiler_version:
-- '10'
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -17,7 +17,7 @@ curl:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '10'
+- '11'
 libcurl:
 - '7'
 libprotobuf:

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -16,6 +16,7 @@ cmake ^
     -DTBB_FOUND=1 ^
     -DTBB_INCLUDEDIR=%LIBRARY_PREFIX%\include ^
     -DTBB_LIBRARY_DIR=%LIBRARY_PREFIX%\lib ^
+    -DUSE_EXTERNAL_TINY_PROCESS_LIBRARY=ON ^
     %SRC_DIR%
 if errorlevel 1 exit 1
 

--- a/recipe/fix_build.patch
+++ b/recipe/fix_build.patch
@@ -146,53 +146,6 @@ index 90f7ee01ed..0959f3d4c3 100644
    ${Boost_LIBRARIES})
  
  if (HAVE_BULLET)
-diff --git a/gazebo/gui/plot/qwt_gazebo.h b/gazebo/gui/plot/qwt_gazebo.h
-index c548b91249..8063475108 100644
---- a/gazebo/gui/plot/qwt_gazebo.h
-+++ b/gazebo/gui/plot/qwt_gazebo.h
-@@ -23,24 +23,24 @@
- #pragma clang diagnostic push
- #pragma clang diagnostic ignored "-Wfloat-equal"
- 
--#include <qwt/qwt_curve_fitter.h>
--#include <qwt/qwt_legend.h>
--#include <qwt/qwt_painter.h>
--#include <qwt/qwt_picker_machine.h>
--#include <qwt/qwt_plot.h>
--#include <qwt/qwt_plot_canvas.h>
--#include <qwt/qwt_plot_curve.h>
--#include <qwt/qwt_plot_directpainter.h>
--#include <qwt/qwt_plot_grid.h>
--#include <qwt/qwt_plot_layout.h>
--#include <qwt/qwt_plot_magnifier.h>
--#include <qwt/qwt_plot_marker.h>
--#include <qwt/qwt_plot_panner.h>
--#include <qwt/qwt_plot_zoomer.h>
--#include <qwt/qwt_scale_engine.h>
--#include <qwt/qwt_scale_widget.h>
--#include <qwt/qwt_symbol.h>
--#include <qwt/qwt_plot_renderer.h>
-+#include <qwt_curve_fitter.h>
-+#include <qwt_legend.h>
-+#include <qwt_painter.h>
-+#include <qwt_picker_machine.h>
-+#include <qwt_plot.h>
-+#include <qwt_plot_canvas.h>
-+#include <qwt_plot_curve.h>
-+#include <qwt_plot_directpainter.h>
-+#include <qwt_plot_grid.h>
-+#include <qwt_plot_layout.h>
-+#include <qwt_plot_magnifier.h>
-+#include <qwt_plot_marker.h>
-+#include <qwt_plot_panner.h>
-+#include <qwt_plot_zoomer.h>
-+#include <qwt_scale_engine.h>
-+#include <qwt_scale_widget.h>
-+#include <qwt_symbol.h>
-+#include <qwt_plot_renderer.h>
- 
- #pragma clang diagnostic pop
- 
 diff --git a/gazebo/msgs/CMakeLists.txt b/gazebo/msgs/CMakeLists.txt
 index cc19f5fa1e..32f5d11e04 100644
 --- a/gazebo/msgs/CMakeLists.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
     patches:
       - fix_build.patch  # [unix]
       - use-external-libs-config.patch  # [win]
-      - qwt-fix.patch  # [win]
       - normalize-ogre-path.patch  # [win]
       - fix_boost_include.patch
 
@@ -77,6 +76,7 @@ requirements:
     # - gts
     - bzip2  # [osx]
     - zlib  # [osx]
+    - tiny-process-library  # [win]
 
   run:
     - xorg-libxext      # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,7 @@ source:
   - url: https://github.com/osrf/{{ name }}/archive/{{ name }}{{ version.split('.')[0] }}_{{ version }}.tar.gz
     sha256: b3c14fc1a123be2992b880efa11d362d3d06c77d8c9624a14c487357ec7623f1
     patches:
+      - fix_build.patch  # [unix]
       - use-external-libs-config.patch  # [win]
       - normalize-ogre-path.patch  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,6 @@ source:
   - url: https://github.com/osrf/{{ name }}/archive/{{ name }}{{ version.split('.')[0] }}_{{ version }}.tar.gz
     sha256: b3c14fc1a123be2992b880efa11d362d3d06c77d8c9624a14c487357ec7623f1
     patches:
-      - fix_build.patch  # [unix]
       - use-external-libs-config.patch  # [win]
       - normalize-ogre-path.patch  # [win]
       - fix_boost_include.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "gazebo" %}
-{% set version = "11.2.0" %}
+{% set version = "11.3.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   - url: https://github.com/osrf/{{ name }}/archive/{{ name }}{{ version.split('.')[0] }}_{{ version }}.tar.gz
-    sha256: 4b59b5d43805ca094dfe06027b1cbcb5fb81790c873cdce6ad41e270f0cc7fc4
+    sha256: b3c14fc1a123be2992b880efa11d362d3d06c77d8c9624a14c487357ec7623f1
     patches:
       - fix_build.patch  # [unix]
       - use-external-libs-config.patch  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
     patches:
       - use-external-libs-config.patch  # [win]
       - normalize-ogre-path.patch  # [win]
-      - fix_boost_include.patch
 
 build:
   number: 0


### PR DESCRIPTION
Version based on https://github.com/conda-forge/gazebo-feedstock/pull/36 with some fixes.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
