### PR TITLE
Backport upstream PR 2609 and fix find_package(gazebo) on Windows

### DIFF
--- a/recipe/2906.patch
+++ b/recipe/2906.patch
@@ -1,0 +1,36 @@
+From d05c6a0782bf02651a8e1d971fc42601a6adfb15 Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio@traversaro.it>
+Date: Sat, 12 Dec 2020 15:57:49 +0100
+Subject: [PATCH] Fix find_package(gazebo) on Windows
+
+Fix https://github.com/osrf/gazebo/issues/2905
+---
+ CMakeLists.txt | 15 +++++++++++++--
+ 1 file changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 84489b6f9f..277aac87e1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -434,8 +434,19 @@ else (build_errors)
+   # Order is important, if A depends on B, please add B after A.
+   # The list should have at the very end the libraries
+   # without internal interdependencies
+-  set(PKG_LIBRARIES
+-    gazebo
++  
++  # The gazebo library on Windows is called libgazebo to avoid 
++  # conflicts with the gazebo executable
++  if(NOT WIN32)
++    set(PKG_LIBRARIES
++      gazebo
++    )
++  else()
++    set(PKG_LIBRARIES
++      libgazebo
++    )
++  endif()  
++  set(PKG_LIBRARIES ${PKG_LIBRARIES}
+     gazebo_client
+     gazebo_gui
+     gazebo_sensors

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ source:
       - use-external-libs-config.patch
       - normalize-ogre-path.patch
       - cmake_129_workaround.patch  # [unix]
+      - 2906.patch
 
 build:
   number: 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
       - 2906.patch
 
 build:
-  number: 2
+  number: 3
   skip: false
   run_exports:
     - {{ pin_subpackage('gazebo', max_pin='x') }}


### PR DESCRIPTION
Gazebo 11.3.0 contains a regression on Windows (described in https://github.com/osrf/gazebo/issues/2905) that was fixed in https://github.com/osrf/gazebo/pull/2906 . This PR backports the fix to it. 

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

