### PR TITLE
Build against qt 5.12.9*_4

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -7,3 +7,8 @@ MACOSX_DEPLOYMENT_TARGET:      # [osx and x86_64]
 OGRE_VERSION:
   - "1.10"
   - "1.12"
+
+# Workaround for https://github.com/conda-forge/gazebo-feedstock/issues/119
+QT_VERSION:
+  - "working"
+  - "latest"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -7,8 +7,3 @@ MACOSX_DEPLOYMENT_TARGET:      # [osx and x86_64]
 OGRE_VERSION:
   - "1.10"
   - "1.12"
-
-# Workaround for https://github.com/conda-forge/gazebo-feedstock/issues/119
-QT_VERSION:
-  - "working"
-  - "latest"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,7 +64,7 @@ requirements:
     - libignition-transport8
     - libignition-common3
     - libignition-fuel-tools4
-    - qt 5.12.9=hda022c4_4
+    - qt 5.12.9*_4
     {% if OGRE_VERSION == "1.10" %}
     - ogre 1.10.*
     {% else %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
       - 3146.patch
 
 build:
-  number: 3
+  number: 4
   run_exports:
     - {{ pin_subpackage('gazebo', max_pin='x') }}
 
@@ -64,7 +64,7 @@ requirements:
     - libignition-transport8
     - libignition-common3
     - libignition-fuel-tools4
-    - qt
+    - qt=5.12.9=hda022c4_4
     {% if OGRE_VERSION == "1.10" %}
     - ogre 1.10.*
     {% else %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,7 +64,7 @@ requirements:
     - libignition-transport8
     - libignition-common3
     - libignition-fuel-tools4
-    - qt 5.12.9*_4
+    - qt 5.12.9 *_4
     {% if OGRE_VERSION == "1.10" %}
     - ogre 1.10.*
     {% else %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,7 +64,7 @@ requirements:
     - libignition-transport8
     - libignition-common3
     - libignition-fuel-tools4
-    - qt=5.12.9=hda022c4_4
+    - qt 5.12.9=hda022c4_4
     {% if OGRE_VERSION == "1.10" %}
     - ogre 1.10.*
     {% else %}


### PR DESCRIPTION
Until we figure out https://github.com/conda-forge/gazebo-feedstock/issues/119, this should ensure that:
~~~
mamba install gazebo qt=5.12.9=hda022c4_4
~~~
can install the latest gazebo (at the moment it install the non-working gazebo 1.10). Note that we do not enforce any run constraint on qt, so in any case it will be necessary to install explicitly `qt=5.12.9=hda022c4_4`. 

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
