### PR TITLE
Bump build number, prepare to libprotobuf 3.20 and switch to vs2019

### DIFF
--- a/.ci_support/linux_64_OGRE_VERSION1.10QT_VERSION5.12.yaml
+++ b/.ci_support/linux_64_OGRE_VERSION1.10QT_VERSION5.12.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 ffmpeg:
-- '4.3'
+- '4.4'
 graphviz:
 - '2.47'
 hdf5:
@@ -32,8 +32,6 @@ libcurl:
 - '7'
 libgdal:
 - '3.4'
-libprotobuf:
-- '3.19'
 libuuid:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_OGRE_VERSION1.10QT_VERSION5.15.yaml
+++ b/.ci_support/linux_64_OGRE_VERSION1.10QT_VERSION5.15.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 ffmpeg:
-- '4.3'
+- '4.4'
 graphviz:
 - '2.47'
 hdf5:
@@ -32,8 +32,6 @@ libcurl:
 - '7'
 libgdal:
 - '3.4'
-libprotobuf:
-- '3.19'
 libuuid:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_OGRE_VERSION1.12QT_VERSION5.12.yaml
+++ b/.ci_support/linux_64_OGRE_VERSION1.12QT_VERSION5.12.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 ffmpeg:
-- '4.3'
+- '4.4'
 graphviz:
 - '2.47'
 hdf5:
@@ -32,8 +32,6 @@ libcurl:
 - '7'
 libgdal:
 - '3.4'
-libprotobuf:
-- '3.19'
 libuuid:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_OGRE_VERSION1.12QT_VERSION5.15.yaml
+++ b/.ci_support/linux_64_OGRE_VERSION1.12QT_VERSION5.15.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 ffmpeg:
-- '4.3'
+- '4.4'
 graphviz:
 - '2.47'
 hdf5:
@@ -32,8 +32,6 @@ libcurl:
 - '7'
 libgdal:
 - '3.4'
-libprotobuf:
-- '3.19'
 libuuid:
 - '2'
 pin_run_as_build:

--- a/.ci_support/osx_64_OGRE_VERSION1.10QT_VERSION5.12.yaml
+++ b/.ci_support/osx_64_OGRE_VERSION1.10QT_VERSION5.12.yaml
@@ -23,7 +23,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '12'
 ffmpeg:
-- '4.3'
+- '4.4'
 graphviz:
 - '2.47'
 hdf5:
@@ -32,8 +32,6 @@ libcurl:
 - '7'
 libgdal:
 - '3.4'
-libprotobuf:
-- '3.19'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_64_OGRE_VERSION1.10QT_VERSION5.15.yaml
+++ b/.ci_support/osx_64_OGRE_VERSION1.10QT_VERSION5.15.yaml
@@ -23,7 +23,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '12'
 ffmpeg:
-- '4.3'
+- '4.4'
 graphviz:
 - '2.47'
 hdf5:
@@ -32,8 +32,6 @@ libcurl:
 - '7'
 libgdal:
 - '3.4'
-libprotobuf:
-- '3.19'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_64_OGRE_VERSION1.12QT_VERSION5.12.yaml
+++ b/.ci_support/osx_64_OGRE_VERSION1.12QT_VERSION5.12.yaml
@@ -23,7 +23,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '12'
 ffmpeg:
-- '4.3'
+- '4.4'
 graphviz:
 - '2.47'
 hdf5:
@@ -32,8 +32,6 @@ libcurl:
 - '7'
 libgdal:
 - '3.4'
-libprotobuf:
-- '3.19'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_64_OGRE_VERSION1.12QT_VERSION5.15.yaml
+++ b/.ci_support/osx_64_OGRE_VERSION1.12QT_VERSION5.15.yaml
@@ -23,7 +23,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '12'
 ffmpeg:
-- '4.3'
+- '4.4'
 graphviz:
 - '2.47'
 hdf5:
@@ -32,8 +32,6 @@ libcurl:
 - '7'
 libgdal:
 - '3.4'
-libprotobuf:
-- '3.19'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_arm64_OGRE_VERSION1.10.yaml
+++ b/.ci_support/osx_arm64_OGRE_VERSION1.10.yaml
@@ -23,7 +23,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '12'
 ffmpeg:
-- '4.3'
+- '4.4'
 graphviz:
 - '2.47'
 hdf5:
@@ -32,8 +32,6 @@ libcurl:
 - '7'
 libgdal:
 - '3.4'
-libprotobuf:
-- '3.19'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_OGRE_VERSION1.12.yaml
+++ b/.ci_support/osx_arm64_OGRE_VERSION1.12.yaml
@@ -23,7 +23,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '12'
 ffmpeg:
-- '4.3'
+- '4.4'
 graphviz:
 - '2.47'
 hdf5:
@@ -32,8 +32,6 @@ libcurl:
 - '7'
 libgdal:
 - '3.4'
-libprotobuf:
-- '3.19'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/win_64_OGRE_VERSION1.10QT_VERSION5.12.yaml
+++ b/.ci_support/win_64_OGRE_VERSION1.10QT_VERSION5.12.yaml
@@ -5,7 +5,7 @@ QT_VERSION:
 boost_cpp:
 - 1.74.0
 c_compiler:
-- vs2017
+- vs2019
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,7 +13,7 @@ channel_targets:
 curl:
 - '7'
 cxx_compiler:
-- vs2017
+- vs2019
 ffmpeg:
 - '4.3'
 hdf5:

--- a/.ci_support/win_64_OGRE_VERSION1.10QT_VERSION5.12.yaml
+++ b/.ci_support/win_64_OGRE_VERSION1.10QT_VERSION5.12.yaml
@@ -22,8 +22,6 @@ libcurl:
 - '7'
 libgdal:
 - '3.4'
-libprotobuf:
-- '3.19'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x

--- a/.ci_support/win_64_OGRE_VERSION1.10QT_VERSION5.15.yaml
+++ b/.ci_support/win_64_OGRE_VERSION1.10QT_VERSION5.15.yaml
@@ -5,7 +5,7 @@ QT_VERSION:
 boost_cpp:
 - 1.74.0
 c_compiler:
-- vs2017
+- vs2019
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,7 +13,7 @@ channel_targets:
 curl:
 - '7'
 cxx_compiler:
-- vs2017
+- vs2019
 ffmpeg:
 - '4.3'
 hdf5:

--- a/.ci_support/win_64_OGRE_VERSION1.10QT_VERSION5.15.yaml
+++ b/.ci_support/win_64_OGRE_VERSION1.10QT_VERSION5.15.yaml
@@ -22,8 +22,6 @@ libcurl:
 - '7'
 libgdal:
 - '3.4'
-libprotobuf:
-- '3.19'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x

--- a/.ci_support/win_64_OGRE_VERSION1.12QT_VERSION5.12.yaml
+++ b/.ci_support/win_64_OGRE_VERSION1.12QT_VERSION5.12.yaml
@@ -5,7 +5,7 @@ QT_VERSION:
 boost_cpp:
 - 1.74.0
 c_compiler:
-- vs2017
+- vs2019
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,7 +13,7 @@ channel_targets:
 curl:
 - '7'
 cxx_compiler:
-- vs2017
+- vs2019
 ffmpeg:
 - '4.3'
 hdf5:

--- a/.ci_support/win_64_OGRE_VERSION1.12QT_VERSION5.12.yaml
+++ b/.ci_support/win_64_OGRE_VERSION1.12QT_VERSION5.12.yaml
@@ -22,8 +22,6 @@ libcurl:
 - '7'
 libgdal:
 - '3.4'
-libprotobuf:
-- '3.19'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x

--- a/.ci_support/win_64_OGRE_VERSION1.12QT_VERSION5.15.yaml
+++ b/.ci_support/win_64_OGRE_VERSION1.12QT_VERSION5.15.yaml
@@ -5,7 +5,7 @@ QT_VERSION:
 boost_cpp:
 - 1.74.0
 c_compiler:
-- vs2017
+- vs2019
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,7 +13,7 @@ channel_targets:
 curl:
 - '7'
 cxx_compiler:
-- vs2017
+- vs2019
 ffmpeg:
 - '4.3'
 hdf5:

--- a/.ci_support/win_64_OGRE_VERSION1.12QT_VERSION5.15.yaml
+++ b/.ci_support/win_64_OGRE_VERSION1.12QT_VERSION5.15.yaml
@@ -22,8 +22,6 @@ libcurl:
 - '7'
 libgdal:
 - '3.4'
-libprotobuf:
-- '3.19'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x

--- a/README.md
+++ b/README.md
@@ -149,16 +149,41 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `gazebo` can be installed with:
+Once the `conda-forge` channel has been enabled, `gazebo` can be installed with `conda`:
 
 ```
 conda install gazebo
 ```
 
-It is possible to list all of the versions of `gazebo` available on your platform with:
+or with `mamba`:
+
+```
+mamba install gazebo
+```
+
+It is possible to list all of the versions of `gazebo` available on your platform with `conda`:
 
 ```
 conda search gazebo --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search gazebo --channel conda-forge
+```
+
+Alternatively, `mamba repoquery` may provide more information:
+
+```
+# Search all versions available on your platform:
+mamba repoquery search gazebo --channel conda-forge
+
+# List packages depending on `gazebo`:
+mamba repoquery whoneeds gazebo --channel conda-forge
+
+# List dependencies of `gazebo`:
+mamba repoquery depends gazebo --channel conda-forge
 ```
 
 
@@ -176,10 +201,12 @@ for each of the installable packages. Such a repository is known as a *feedstock
 A feedstock is made up of a conda recipe (the instructions on what and how to build
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
-[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
-packages to the [conda-forge](https://anaconda.org/conda-forge)
-[Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
+[Azure](https://azure.microsoft.com/en-us/services/devops/), [GitHub](https://github.com/),
+[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/),
+[Drone](https://cloud.drone.io/welcome), and [TravisCI](https://travis-ci.com/)
+it is possible to build and upload installable packages to the
+[conda-forge](https://anaconda.org/conda-forge) [Anaconda-Cloud](https://anaconda.org/)
+channel for Linux, Windows and OSX respectively.
 
 To manage the continuous integration and simplify feedstock maintenance
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.

--- a/recipe/3211.patch
+++ b/recipe/3211.patch
@@ -1,0 +1,29 @@
+diff --git a/gazebo/msgs/generator/GazeboGenerator.cc b/gazebo/msgs/generator/GazeboGenerator.cc
+index 0a681f6dec..10d76c7df6 100644
+--- a/gazebo/msgs/generator/GazeboGenerator.cc
++++ b/gazebo/msgs/generator/GazeboGenerator.cc
+@@ -37,7 +37,7 @@ namespace cpp {
+ GazeboGenerator::GazeboGenerator(const std::string &/*_name*/) {}
+ GazeboGenerator::~GazeboGenerator() {}
+ bool GazeboGenerator::Generate(const FileDescriptor *_file,
+-                               const string &/*parameter*/,
++                               const std::string &/*parameter*/,
+                                OutputDirectory *_generator_context,
+                                std::string * /*_error*/) const
+ {
+diff --git a/gazebo/msgs/generator/GazeboGenerator.hh b/gazebo/msgs/generator/GazeboGenerator.hh
+index 6900e281aa..665deb8329 100644
+--- a/gazebo/msgs/generator/GazeboGenerator.hh
++++ b/gazebo/msgs/generator/GazeboGenerator.hh
+@@ -37,9 +37,9 @@ class GazeboGenerator : public CodeGenerator
+   public: virtual ~GazeboGenerator();
+ 
+   public: virtual bool Generate(const FileDescriptor* file,
+-                const string& parameter,
++                const std::string& parameter,
+                 OutputDirectory *directory,
+-                string* error) const;
++                std::string* error) const;
+ 
+   // private: GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(GazeboGenerator);
+ };

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -7,6 +7,11 @@ MACOSX_DEPLOYMENT_TARGET:      # [osx and x86_64]
 OGRE_VERSION:
   - "1.10"
   - "1.12"
+  
+c_compiler:  # [win]
+- vs2019  # [win]
+cxx_compiler:  # [win]
+- vs2019  # [win]
 
 # This is done to build for both qt (5.12) and qt-main (5.15)
 # until conda-forge as an whole migrate to 5.15 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
       - 3190.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('gazebo', max_pin='x') }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
       - normalize-ogre-path.patch
       - fix-invisible-meshes.patch
       - 3190.patch
+      - 3211.patch
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,7 @@ requirements:
     - {{ cdt('libxau') }}            # [linux]
     - {{ cdt('expat-devel') }}       # [linux]
     # We need all host deps also in build for cross-compiling gazebomsgs_out
-    - libprotobuf  # [build_platform != target_platform]
+    - libprotobuf 3.20  # [build_platform != target_platform]
     - libsdformat  # [build_platform != target_platform]
     - libignition-cmake2  # [build_platform != target_platform]
     - libignition-math6  # [build_platform != target_platform]
@@ -88,7 +88,7 @@ requirements:
     - xorg-libsm        # [unix]
     - libglu            # [linux]
     # deps
-    - libprotobuf
+    - libprotobuf 3.20
     - libsdformat
     - libignition-cmake2
     - libignition-math6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,7 @@ requirements:
     - {{ cdt('libxau') }}            # [linux]
     - {{ cdt('expat-devel') }}       # [linux]
     # We need all host deps also in build for cross-compiling gazebomsgs_out
-    - libprotobuf 3.20  # [build_platform != target_platform]
+    - libprotobuf  # [build_platform != target_platform]
     - libsdformat  # [build_platform != target_platform]
     - libignition-cmake2  # [build_platform != target_platform]
     - libignition-math6  # [build_platform != target_platform]
@@ -89,7 +89,7 @@ requirements:
     - xorg-libsm        # [unix]
     - libglu            # [linux]
     # deps
-    - libprotobuf 3.20
+    - libprotobuf
     - libsdformat
     - libignition-cmake2
     - libignition-math6


### PR DESCRIPTION
Debug the reason why the libprotobuf320 migration is failing.


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
