### PR TITLE
Bump build number to 9 to build against recent libignition-fuel-tools4

### DIFF
--- a/.ci_support/migrations/ffmpeg44.yaml
+++ b/.ci_support/migrations/ffmpeg44.yaml
@@ -1,8 +1,0 @@
-migrator_ts: 1657582548
-__migrator:
-  kind: version
-  migration_number: 1
-  bump_number: 1
-
-ffmpeg:
-  - 4.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
       - 3190.patch
 
 build:
-  number: 8
+  number: 9
   run_exports:
     - {{ pin_subpackage('gazebo', max_pin='x') }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ requirements:
     - {{ cdt('libxdamage') }}        # [linux]
     - {{ cdt('libxfixes') }}         # [linux]
     - {{ cdt('libxxf86vm') }}        # [linux]
-    - {{ cdt('libxext') }}           # [linux]
+    - {{ cdt('libxext') }}           # [flinux]
     - {{ cdt('libxau') }}            # [linux]
     - {{ cdt('expat-devel') }}       # [linux]
     # We need all host deps also in build for cross-compiling gazebomsgs_out
@@ -85,7 +85,8 @@ requirements:
     - libignition-math6
     - libignition-transport8
     - libignition-common3
-    - libignition-fuel-tools4
+    # Workaround for https://github.com/conda-forge/gazebo-feedstock/pull/143
+    - libignition-fuel-tools4 >=4.4
     - libignition-msgs5
     {% if OGRE_VERSION == "1.10" %}
     - ogre 1.10.*


### PR DESCRIPTION
Apparently gazebo in https://github.com/conda-forge/gazebo-feedstock/pull/141 was built with an old libignition-fuel-tools4 with no ffmpeg support, probably because the build compiled with ffmpeg44 was still not available. Apparently the migrator was not aware of the transitive dependency between gazebo and libignition-fuel-tools4.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
