### PR TITLE
Pin graphviz to 6 until run_exports is fixed

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -19,6 +19,7 @@ jobs:
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\
+    UPLOAD_TEMP: D:\\tmp
 
   steps:
     - task: PythonScript@0
@@ -104,6 +105,9 @@ jobs:
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
         set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
+        set "TEMP=$(UPLOAD_TEMP)"
+        if not exist "%TEMP%\" md "%TEMP%"
+        set "TMP=%TEMP%"
         call activate base
         upload_package --validate --feedstock-name="%FEEDSTOCK_NAME%" .\ ".\recipe" .ci_support\%CONFIG%.yaml
       displayName: Upload package

--- a/.ci_support/linux_64_OGRE_VERSION1.10.yaml
+++ b/.ci_support/linux_64_OGRE_VERSION1.10.yaml
@@ -7,7 +7,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 channel_sources:
@@ -19,13 +19,11 @@ curl:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 ffmpeg:
 - '5'
-graphviz:
-- '6'
 hdf5:
 - 1.12.2
 libblas:
@@ -43,8 +41,6 @@ libuuid:
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
-  graphviz:
-    max_pin: x
 qt_main:
 - '5.15'
 target_platform:

--- a/.ci_support/linux_64_OGRE_VERSION1.12.yaml
+++ b/.ci_support/linux_64_OGRE_VERSION1.12.yaml
@@ -7,7 +7,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 channel_sources:
@@ -19,13 +19,11 @@ curl:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 ffmpeg:
 - '5'
-graphviz:
-- '6'
 hdf5:
 - 1.12.2
 libblas:
@@ -43,8 +41,6 @@ libuuid:
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
-  graphviz:
-    max_pin: x
 qt_main:
 - '5.15'
 target_platform:

--- a/.ci_support/linux_aarch64_OGRE_VERSION1.10.yaml
+++ b/.ci_support/linux_aarch64_OGRE_VERSION1.10.yaml
@@ -9,7 +9,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -23,13 +23,11 @@ curl:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 ffmpeg:
 - '5'
-graphviz:
-- '6'
 hdf5:
 - 1.12.2
 libblas:
@@ -47,8 +45,6 @@ libuuid:
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
-  graphviz:
-    max_pin: x
 qt_main:
 - '5.15'
 target_platform:

--- a/.ci_support/linux_aarch64_OGRE_VERSION1.12.yaml
+++ b/.ci_support/linux_aarch64_OGRE_VERSION1.12.yaml
@@ -9,7 +9,7 @@ boost_cpp:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -23,13 +23,11 @@ curl:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 ffmpeg:
 - '5'
-graphviz:
-- '6'
 hdf5:
 - 1.12.2
 libblas:
@@ -47,8 +45,6 @@ libuuid:
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
-  graphviz:
-    max_pin: x
 qt_main:
 - '5.15'
 target_platform:

--- a/.ci_support/migrations/libgdal36.yaml
+++ b/.ci_support/migrations/libgdal36.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-libgdal:
-- '3.6'
-migrator_ts: 1668608830.3535678

--- a/.ci_support/osx_64_OGRE_VERSION1.10.yaml
+++ b/.ci_support/osx_64_OGRE_VERSION1.10.yaml
@@ -24,8 +24,6 @@ cxx_compiler_version:
 - '14'
 ffmpeg:
 - '5'
-graphviz:
-- '6'
 hdf5:
 - 1.12.2
 libblas:
@@ -45,8 +43,6 @@ macos_min_version:
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
-  graphviz:
-    max_pin: x
 qt_main:
 - '5.15'
 target_platform:

--- a/.ci_support/osx_64_OGRE_VERSION1.12.yaml
+++ b/.ci_support/osx_64_OGRE_VERSION1.12.yaml
@@ -24,8 +24,6 @@ cxx_compiler_version:
 - '14'
 ffmpeg:
 - '5'
-graphviz:
-- '6'
 hdf5:
 - 1.12.2
 libblas:
@@ -45,8 +43,6 @@ macos_min_version:
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
-  graphviz:
-    max_pin: x
 qt_main:
 - '5.15'
 target_platform:

--- a/.ci_support/osx_arm64_OGRE_VERSION1.10.yaml
+++ b/.ci_support/osx_arm64_OGRE_VERSION1.10.yaml
@@ -24,8 +24,6 @@ cxx_compiler_version:
 - '14'
 ffmpeg:
 - '5'
-graphviz:
-- '6'
 hdf5:
 - 1.12.2
 libblas:
@@ -43,8 +41,6 @@ macos_machine:
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
-  graphviz:
-    max_pin: x
 qt_main:
 - '5.15'
 target_platform:

--- a/.ci_support/osx_arm64_OGRE_VERSION1.12.yaml
+++ b/.ci_support/osx_arm64_OGRE_VERSION1.12.yaml
@@ -24,8 +24,6 @@ cxx_compiler_version:
 - '14'
 ffmpeg:
 - '5'
-graphviz:
-- '6'
 hdf5:
 - 1.12.2
 libblas:
@@ -43,8 +41,6 @@ macos_machine:
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
-  graphviz:
-    max_pin: x
 qt_main:
 - '5.15'
 target_platform:

--- a/.ci_support/win_64_OGRE_VERSION1.10.yaml
+++ b/.ci_support/win_64_OGRE_VERSION1.10.yaml
@@ -16,8 +16,6 @@ cxx_compiler:
 - vs2019
 ffmpeg:
 - '5'
-graphviz:
-- '6'
 hdf5:
 - 1.12.2
 libblas:
@@ -33,8 +31,6 @@ libprotobuf:
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
-  graphviz:
-    max_pin: x
 qt_main:
 - '5.15'
 target_platform:

--- a/.ci_support/win_64_OGRE_VERSION1.12.yaml
+++ b/.ci_support/win_64_OGRE_VERSION1.12.yaml
@@ -16,8 +16,6 @@ cxx_compiler:
 - vs2019
 ffmpeg:
 - '5'
-graphviz:
-- '6'
 hdf5:
 - 1.12.2
 libblas:
@@ -33,8 +31,6 @@ libprotobuf:
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
-  graphviz:
-    max_pin: x
 qt_main:
 - '5.15'
 target_platform:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
       - 3270.patch
 
 build:
-  number: 4
+  number: 5
   run_exports:
     - {{ pin_subpackage('gazebo', max_pin='x') }}
 
@@ -114,7 +114,7 @@ requirements:
     - zlib  # [osx]
     - tiny-process-library  # [win]
     - ffmpeg
-    - graphviz
+    - graphviz 6
     - libgdal
     - libusb
     # Bullet is not detected on win for some reason
@@ -144,8 +144,7 @@ requirements:
     # deps
     - boost-cpp
     - tbb-devel
-    # graphviz is not found on win
-    - graphviz  # [not win]
+    - graphviz 6
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
 
 test:


### PR DESCRIPTION
Fix https://github.com/conda-forge/gazebo-feedstock/issues/159 .

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
