### PR TITLE
Apply 3269.patch also on non-Windows platforms

### DIFF
--- a/.ci_support/migrations/assimp525.yaml
+++ b/.ci_support/migrations/assimp525.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-assimp:
-- 5.2.5
-migrator_ts: 1663100710.2627342

--- a/.ci_support/migrations/hdf51122.yaml
+++ b/.ci_support/migrations/hdf51122.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-hdf5:
-- 1.12.2
-migrator_ts: 1658944374.2290778

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,11 +13,11 @@ source:
       - use-external-libs-config.patch
       - fix-invisible-meshes.patch
       - 3190.patch
-      - 3269.patch  # [win]
+      - 3269.patch
       - 3270.patch
 
 build:
-  number: 5
+  number: 6
   run_exports:
     - {{ pin_subpackage('gazebo', max_pin='x') }}
 


### PR DESCRIPTION
The patch was introduced in https://github.com/conda-forge/gazebo-feedstock/pull/152 to fix a macOS-specific issue, but we accedentally started to apply only on Windows in https://github.com/conda-forge/gazebo-feedstock/pull/154 . This PR remove the `# [win]` selector so the patch is applied also on macOS, fixing https://github.com/conda-forge/gazebo-feedstock/issues/161 .