### PR TITLE
Remove graphviz 6 pin and migrate to graphviz 8

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -22,6 +22,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 ffmpeg:
 - '5'
+graphviz:
+- '8'
 hdf5:
 - 1.14.0
 libblas:
@@ -39,6 +41,8 @@ libuuid:
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
+  graphviz:
+    max_pin: x
 qt_main:
 - '5.15'
 target_platform:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -26,6 +26,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 ffmpeg:
 - '5'
+graphviz:
+- '8'
 hdf5:
 - 1.14.0
 libblas:
@@ -43,6 +45,8 @@ libuuid:
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
+  graphviz:
+    max_pin: x
 qt_main:
 - '5.15'
 target_platform:

--- a/.ci_support/migrations/ffmpeg5.yaml
+++ b/.ci_support/migrations/ffmpeg5.yaml
@@ -1,8 +1,0 @@
-migrator_ts: 1666482468
-__migrator:
-  kind: version
-  migration_number: 2
-  bump_number: 1
-
-ffmpeg:
-  - 5

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '15'
 ffmpeg:
 - '5'
+graphviz:
+- '8'
 hdf5:
 - 1.14.0
 libblas:
@@ -41,6 +43,8 @@ macos_min_version:
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
+  graphviz:
+    max_pin: x
 qt_main:
 - '5.15'
 target_platform:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '15'
 ffmpeg:
 - '5'
+graphviz:
+- '8'
 hdf5:
 - 1.14.0
 libblas:
@@ -39,6 +41,8 @@ macos_machine:
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
+  graphviz:
+    max_pin: x
 qt_main:
 - '5.15'
 target_platform:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - vs2019
 ffmpeg:
 - '5'
+graphviz:
+- '8'
 hdf5:
 - 1.14.0
 libblas:
@@ -29,6 +31,8 @@ libprotobuf:
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
+  graphviz:
+    max_pin: x
 qt_main:
 - '5.15'
 target_platform:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
       - 3270.patch
 
 build:
-  number: 11
+  number: 12
   run_exports:
     - {{ pin_subpackage('gazebo', max_pin='x') }}
 
@@ -101,7 +101,7 @@ requirements:
     - zlib  # [osx]
     - tiny-process-library  # [win]
     - ffmpeg
-    - graphviz 6
+    - graphviz
     - libgdal
     - libusb
     # Bullet is not detected on win for some reason
@@ -131,7 +131,6 @@ requirements:
     # deps
     - boost-cpp
     - tbb-devel
-    - graphviz 6
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
 
 test:


### PR DESCRIPTION
The current pinned version is https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/cc301b65120abeaa7a7639564b0a3736387f1598/recipe/conda_build_config.yaml#L391 and graphviz 8 has run_exports since https://github.com/conda-forge/graphviz-feedstock/pull/125 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
