### PR TITLE
Add constraint on build number for old ogre builds

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -130,7 +130,7 @@ requirements:
     - boost-cpp
     - tbb-devel
     # Workaround for failures like https://github.com/robotology/gazebo-yarp-plugins/issues/664
-    - ogre >=1.10.12[build_number=3]
+    - ogre  >=1.10.12[build_number=3]
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -129,7 +129,7 @@ requirements:
     # deps
     - boost-cpp
     - tbb-devel
-    - ogre  >=1.10.12[build_number=3]
+    - ogre >=1.10.12[build_number=3]
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
       - 3331.patch
 
 build:
-  number: 6
+  number: 7
   run_exports:
     - {{ pin_subpackage('gazebo', max_pin='x') }}
 
@@ -129,6 +129,8 @@ requirements:
     # deps
     - boost-cpp
     - tbb-devel
+    # Workaround for failures like https://github.com/robotology/gazebo-yarp-plugins/issues/664
+    - ogre >=1.10.12[build_number=3]
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -127,7 +127,7 @@ requirements:
     - xorg-libsm        # [unix]
     - libglu            # [linux]
     # deps
-    - "ogre>=1.10.12[build_number=3]"
+    - "ogre >=1.10.12[build_number=3]"
     - boost-cpp
     - tbb-devel
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -129,7 +129,6 @@ requirements:
     # deps
     - boost-cpp
     - tbb-devel
-    # Workaround for failures like https://github.com/robotology/gazebo-yarp-plugins/issues/664
     - ogre  >=1.10.12[build_number=3]
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -127,7 +127,7 @@ requirements:
     - xorg-libsm        # [unix]
     - libglu            # [linux]
     # deps
-    - ogre >=1.10.12[build_number=3]
+    - ogre ">=1.10.12[build_number=3]"
     - boost-cpp
     - tbb-devel
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -127,6 +127,7 @@ requirements:
     - xorg-libsm        # [unix]
     - libglu            # [linux]
     # deps
+    - ogre >=1.10.12[build_number=3]
     - boost-cpp
     - tbb-devel
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -129,7 +129,6 @@ requirements:
     # deps
     - boost-cpp
     - tbb-devel
-    - ogre >=1.10.12[build_number=3]
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -127,7 +127,7 @@ requirements:
     - xorg-libsm        # [unix]
     - libglu            # [linux]
     # deps
-    - ogre ">=1.10.12[build_number=3]"
+    - "ogre>=1.10.12[build_number=3]"
     - boost-cpp
     - tbb-devel
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -127,9 +127,11 @@ requirements:
     - xorg-libsm        # [unix]
     - libglu            # [linux]
     # deps
-    - "ogre >=1.10.12[build_number=3]"
     - boost-cpp
     - tbb-devel
+    # Add constraint to avoid that old ogre gets installed during migratons,
+    # see https://github.com/conda-forge/gazebo-feedstock/pull/188/files
+    - "ogre >=1.10.12[build_number=3]"
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
 
 test:


### PR DESCRIPTION
There are some old ogre builds (`1.10.12=*_2`) that were build without the features required by Gazebo, and that are pulled in when there is some in-progress migration, as they do not have any run constraint on the shared dependencies between Gazebo and Ogre, see:
* https://github.com/robotology/robotology-superbuild/issues/1089
* https://github.com/robotology/gazebo-yarp-plugins/issues/660
* https://github.com/robotology/gazebo-yarp-plugins/issues/664

 To solve this, we can add to gazebo a run constraint to make sure that the ogre version is at least `1.10.12=*_3`.


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
