### PR TITLE
Add run dependency on libboost-devel

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
       - 3347.patch
 
 build:
-  number: 10
+  number: 11
   run_exports:
     - {{ pin_subpackage('gazebo', max_pin='x') }}
 
@@ -128,6 +128,7 @@ requirements:
     - xorg-libsm        # [unix]
     - libglu            # [linux]
     # deps
+    - libboost-devel
     - tbb-devel
     # Add constraint to avoid that old ogre gets installed during migratons,
     # see https://github.com/conda-forge/gazebo-feedstock/pull/188/files


### PR DESCRIPTION
To ensure that `find_package(gazebo REQUIRED)` works fine

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
