### PR TITLE
Add checks that executable works fine also on Windows

### DIFF
--- a/.ci_support/win_64_GZ_CLI_NAME_VARIANTgzcompatname.yaml
+++ b/.ci_support/win_64_GZ_CLI_NAME_VARIANTgzcompatname.yaml
@@ -2,8 +2,6 @@ GZ_CLI_NAME_VARIANT:
 - gzcompatname
 assimp:
 - 5.3.1
-c_compiler:
-- vs2019
 c_stdlib:
 - vs
 channel_sources:
@@ -12,8 +10,6 @@ channel_targets:
 - conda-forge main
 curl:
 - '8'
-cxx_compiler:
-- vs2019
 ffmpeg:
 - '6'
 graphviz:

--- a/.ci_support/win_64_GZ_CLI_NAME_VARIANTorigname.yaml
+++ b/.ci_support/win_64_GZ_CLI_NAME_VARIANTorigname.yaml
@@ -2,8 +2,6 @@ GZ_CLI_NAME_VARIANT:
 - origname
 assimp:
 - 5.3.1
-c_compiler:
-- vs2019
 c_stdlib:
 - vs
 channel_sources:
@@ -12,8 +10,6 @@ channel_targets:
 - conda-forge main
 curl:
 - '8'
-cxx_compiler:
-- vs2019
 ffmpeg:
 - '6'
 graphviz:

--- a/README.md
+++ b/README.md
@@ -3,11 +3,19 @@ About gazebo-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/gazebo-feedstock/blob/main/LICENSE.txt)
 
-Home: http://gazebosim.org/
+Home: http://classic.gazebosim.org/
 
 Package license: Apache-2.0
 
-Summary: Advanced robot simulator for research, design, and development.
+Summary: Gazebo Classic robot simulator for research, design, and development.
+
+This feedstock packages the Gazebo Classic simulator, that will not be supported past 2025.
+For new development, please consider migrating to Modern gz-sim simulator, available in conda-forge.
+To simplify migration to gz-sim, we want to permit to side-by-side installation of gazebo and libgz-tools2, however they both install a command called `gz`.
+So, this feedstock is building two different variants of the `gazebo` conda package:
+  * One that contains `origname` in its build string that has higher priority and is installed if libgz-tools2 is not installed, that uses `gz` as the name for the cli helper of gazebo classic. This variant cannot be installed if `libgz-tools2` is installed. For forward compatibility, this variant also installs a `gz11` command.
+  * One that contains `gzcompatname` that is co-installable with libgz-tools2, but that renames the `gz` commmand line tool to `gz11`.
+
 
 Current build status
 ====================

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -19,6 +19,10 @@ cdt_name:                                         # [linux64]
 c_stdlib_version:   # [linux]
   - "2.17"          # [linux]
 
+c_compiler:    # [win]
+  - vs2022     # [win]
+cxx_compiler:  # [win]
+  - vs2022     # [win]
 
 # We want to permit to side-by-side installation of gazebo
 # and libgz-tools2 to facilitate migration to gz-sim, however

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -19,11 +19,6 @@ cdt_name:                                         # [linux64]
 c_stdlib_version:   # [linux]
   - "2.17"          # [linux]
 
-c_compiler:    # [win]
-  - vs2022     # [win]
-cxx_compiler:  # [win]
-  - vs2022     # [win]
-
 # We want to permit to side-by-side installation of gazebo
 # and libgz-tools2 to facilitate migration to gz-sim, however
 # they both install gz. So, we are building two different variants:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,8 +27,9 @@ build:
 
 requirements:
   build:
-    - {{ compiler('cxx') }}
-    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}  # [not win]
+    - {{ compiler('c') }}  # [not win]
+    - vs2022_win-64
     - {{ stdlib("c") }}
     - cmake
     - pkg-config
@@ -163,7 +164,8 @@ test:
     - gzclient --version | findstr "Gazebo multi-robot simulator, version"  # [win]
     - gazebo --version | findstr "Gazebo multi-robot simulator, version"  # [win]
     # We do not try to check the gz11 help output as it prints on stderr and not stdout
-    - gz11 help
+    # For some reason this fails on aarch64 with Error setting socket option (IP_MULTICAST_IF) error
+    - gz11 help  # [not aarch64]
 
 about:
   home: http://classic.gazebosim.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ build:
   number: {{ number }}
   run_exports:
     - {{ pin_subpackage('gazebo', max_pin='x') }}
-  string: {{ GZ_CLI_NAME_VARIANT }}{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
+  string: {{ GZ_CLI_NAME_VARIANT }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -159,6 +159,11 @@ test:
     - gzserver --version | grep "Gazebo multi-robot simulator, version"  # [unix]
     - gzclient --version | grep "Gazebo multi-robot simulator, version"  # [unix]
     - gazebo --version | grep "Gazebo multi-robot simulator, version"  # [unix]
+    - gzserver --version | findstr "Gazebo multi-robot simulator, version"  # [win]
+    - gzclient --version | findstr "Gazebo multi-robot simulator, version"  # [win]
+    - gazebo --version | findstr "Gazebo multi-robot simulator, version"  # [win]
+    # We do not try to check the gz11 help output as it prints on stderr and not stdout
+    - gz11 help
 
 about:
   home: http://classic.gazebosim.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -159,9 +159,6 @@ test:
     - gzserver --version | grep "Gazebo multi-robot simulator, version"  # [unix]
     - gzclient --version | grep "Gazebo multi-robot simulator, version"  # [unix]
     - gazebo --version | grep "Gazebo multi-robot simulator, version"  # [unix]
-    - gzserver --version | findstr "Gazebo multi-robot simulator, version"  # [win]
-    - gzclient --version | findstr "Gazebo multi-robot simulator, version"  # [win]
-    - gazebo --version | findstr "Gazebo multi-robot simulator, version"  # [win]
     # We do not try to check the gz11 help output as it prints on stderr and not stdout
     # For some reason this fails on aarch64 with Error setting socket option (IP_MULTICAST_IF) error
     - gz11 help  # [not aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,9 +27,8 @@ build:
 
 requirements:
   build:
-    - {{ compiler('cxx') }}  # [not win]
-    - {{ compiler('c') }}  # [not win]
-    - vs2022_win-64
+    - {{ compiler('cxx') }}
+    - {{ compiler('c') }}
     - {{ stdlib("c") }}
     - cmake
     - pkg-config


### PR DESCRIPTION
On of the reasons of https://github.com/gazebosim/gazebo-classic/issues/3379 is that in the CI we were not checking if the executable started correctly on Windows, while we were doing that on non-Windows platforms. This CI adds these check.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
