### PR TITLE
Add check that windows build works fine and fix build string

### DIFF
--- a/.ci_support/win_64_GZ_CLI_NAME_VARIANTgzcompatname.yaml
+++ b/.ci_support/win_64_GZ_CLI_NAME_VARIANTgzcompatname.yaml
@@ -6,6 +6,8 @@ c_compiler:
 - vs2019
 c_stdlib:
 - vs
+c_stdlib_version:
+- '2019'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/win_64_GZ_CLI_NAME_VARIANTorigname.yaml
+++ b/.ci_support/win_64_GZ_CLI_NAME_VARIANTorigname.yaml
@@ -6,6 +6,8 @@ c_compiler:
 - vs2019
 c_stdlib:
 - vs
+c_stdlib_version:
+- '2019'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/README.md
+++ b/README.md
@@ -3,11 +3,19 @@ About gazebo-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/gazebo-feedstock/blob/main/LICENSE.txt)
 
-Home: http://gazebosim.org/
+Home: http://classic.gazebosim.org/
 
 Package license: Apache-2.0
 
-Summary: Advanced robot simulator for research, design, and development.
+Summary: Gazebo Classic robot simulator for research, design, and development.
+
+This feedstock packages the Gazebo Classic simulator, that will not be supported past 2025.
+For new development, please consider migrating to Modern gz-sim simulator, available in conda-forge.
+To simplify migration to gz-sim, we want to permit to side-by-side installation of gazebo and libgz-tools2, however they both install a command called `gz`.
+So, this feedstock is building two different variants of the `gazebo` conda package:
+  * One that contains `origname` in its build string that has higher priority and is installed if libgz-tools2 is not installed, that uses `gz` as the name for the cli helper of gazebo classic. This variant cannot be installed if `libgz-tools2` is installed. For forward compatibility, this variant also installs a `gz11` command.
+  * One that contains `gzcompatname` that is co-installable with libgz-tools2, but that renames the `gz` commmand line tool to `gz11`.
+
 
 Current build status
 ====================

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ build:
   number: {{ number }}
   run_exports:
     - {{ pin_subpackage('gazebo', max_pin='x') }}
-  string: {{ GZ_CLI_NAME_VARIANT }}{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
+  string: {{ GZ_CLI_NAME_VARIANT }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
 
 requirements:
   build:
@@ -159,6 +159,9 @@ test:
     - gzserver --version | grep "Gazebo multi-robot simulator, version"  # [unix]
     - gzclient --version | grep "Gazebo multi-robot simulator, version"  # [unix]
     - gazebo --version | grep "Gazebo multi-robot simulator, version"  # [unix]
+    # We do not try to check the gz11 help output as it prints on stderr and not stdout
+    # For some reason this fails on aarch64 with Error setting socket option (IP_MULTICAST_IF) error
+    - gz11 help  # [not aarch64]
 
 about:
   home: http://classic.gazebosim.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "gazebo" %}
 {% set version = "11.14.0" %}
-{% set number = 11 %}
+{% set number = 12 %}
 
 {% if GZ_CLI_NAME_VARIANT == "origname" %}
 {% set number = number + 200 %}


### PR DESCRIPTION
Thanks to https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5736 this should fix https://github.com/gazebosim/gazebo-classic/issues/3379 . Note that this will be fixed by the re-rendering, the rest of the changes just prevent future regression of this kind (and fix the build string that is an unrelated issue, regression of https://github.com/conda-forge/gazebo-feedstock/pull/208).

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
