### PR TITLE
Fix usage of Gazebo plugins as linked libraries on macOS

### DIFF
--- a/.ci_support/linux_64_GZ_CLI_NAME_VARIANTgzcompatnameffmpeg6.yaml
+++ b/.ci_support/linux_64_GZ_CLI_NAME_VARIANTgzcompatnameffmpeg6.yaml
@@ -50,8 +50,6 @@ libprotobuf:
 - 4.25.3
 libuuid:
 - '2'
-libxcb:
-- '1.15'
 pin_run_as_build:
   graphviz:
     max_pin: x

--- a/.ci_support/linux_64_GZ_CLI_NAME_VARIANTgzcompatnameffmpeg7.yaml
+++ b/.ci_support/linux_64_GZ_CLI_NAME_VARIANTgzcompatnameffmpeg7.yaml
@@ -50,8 +50,6 @@ libprotobuf:
 - 4.25.3
 libuuid:
 - '2'
-libxcb:
-- '1.15'
 pin_run_as_build:
   graphviz:
     max_pin: x

--- a/.ci_support/linux_64_GZ_CLI_NAME_VARIANTorignameffmpeg6.yaml
+++ b/.ci_support/linux_64_GZ_CLI_NAME_VARIANTorignameffmpeg6.yaml
@@ -50,8 +50,6 @@ libprotobuf:
 - 4.25.3
 libuuid:
 - '2'
-libxcb:
-- '1.15'
 pin_run_as_build:
   graphviz:
     max_pin: x

--- a/.ci_support/linux_64_GZ_CLI_NAME_VARIANTorignameffmpeg7.yaml
+++ b/.ci_support/linux_64_GZ_CLI_NAME_VARIANTorignameffmpeg7.yaml
@@ -50,8 +50,6 @@ libprotobuf:
 - 4.25.3
 libuuid:
 - '2'
-libxcb:
-- '1.15'
 pin_run_as_build:
   graphviz:
     max_pin: x

--- a/.ci_support/linux_aarch64_GZ_CLI_NAME_VARIANTgzcompatnameffmpeg6.yaml
+++ b/.ci_support/linux_aarch64_GZ_CLI_NAME_VARIANTgzcompatnameffmpeg6.yaml
@@ -54,8 +54,6 @@ libprotobuf:
 - 4.25.3
 libuuid:
 - '2'
-libxcb:
-- '1.15'
 pin_run_as_build:
   graphviz:
     max_pin: x

--- a/.ci_support/linux_aarch64_GZ_CLI_NAME_VARIANTgzcompatnameffmpeg7.yaml
+++ b/.ci_support/linux_aarch64_GZ_CLI_NAME_VARIANTgzcompatnameffmpeg7.yaml
@@ -54,8 +54,6 @@ libprotobuf:
 - 4.25.3
 libuuid:
 - '2'
-libxcb:
-- '1.15'
 pin_run_as_build:
   graphviz:
     max_pin: x

--- a/.ci_support/linux_aarch64_GZ_CLI_NAME_VARIANTorignameffmpeg6.yaml
+++ b/.ci_support/linux_aarch64_GZ_CLI_NAME_VARIANTorignameffmpeg6.yaml
@@ -54,8 +54,6 @@ libprotobuf:
 - 4.25.3
 libuuid:
 - '2'
-libxcb:
-- '1.15'
 pin_run_as_build:
   graphviz:
     max_pin: x

--- a/.ci_support/linux_aarch64_GZ_CLI_NAME_VARIANTorignameffmpeg7.yaml
+++ b/.ci_support/linux_aarch64_GZ_CLI_NAME_VARIANTorignameffmpeg7.yaml
@@ -54,8 +54,6 @@ libprotobuf:
 - 4.25.3
 libuuid:
 - '2'
-libxcb:
-- '1.15'
 pin_run_as_build:
   graphviz:
     max_pin: x

--- a/.ci_support/migrations/libxcb115.yaml
+++ b/.ci_support/migrations/libxcb115.yaml
@@ -1,9 +1,0 @@
-migrator_ts: 1684619068
-__migrator:
-  kind: version
-  migration_number: 1
-  bump_number: 1
-
-# Remember to add to global pinnings
-libxcb:
-  - '1.15'

--- a/.ci_support/migrations/urdfdom40.yaml
+++ b/.ci_support/migrations/urdfdom40.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for urdfdom 4.0
-  kind: version
-  migration_number: 1
-migrator_ts: 1703639180.921018
-urdfdom:
-- '4.0'

--- a/.ci_support/osx_64_GZ_CLI_NAME_VARIANTgzcompatnameffmpeg6.yaml
+++ b/.ci_support/osx_64_GZ_CLI_NAME_VARIANTgzcompatnameffmpeg6.yaml
@@ -50,8 +50,6 @@ libode:
 - 0.16.2
 libprotobuf:
 - 4.25.3
-libxcb:
-- '1.15'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_64_GZ_CLI_NAME_VARIANTgzcompatnameffmpeg7.yaml
+++ b/.ci_support/osx_64_GZ_CLI_NAME_VARIANTgzcompatnameffmpeg7.yaml
@@ -50,8 +50,6 @@ libode:
 - 0.16.2
 libprotobuf:
 - 4.25.3
-libxcb:
-- '1.15'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_64_GZ_CLI_NAME_VARIANTorignameffmpeg6.yaml
+++ b/.ci_support/osx_64_GZ_CLI_NAME_VARIANTorignameffmpeg6.yaml
@@ -50,8 +50,6 @@ libode:
 - 0.16.2
 libprotobuf:
 - 4.25.3
-libxcb:
-- '1.15'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_64_GZ_CLI_NAME_VARIANTorignameffmpeg7.yaml
+++ b/.ci_support/osx_64_GZ_CLI_NAME_VARIANTorignameffmpeg7.yaml
@@ -50,8 +50,6 @@ libode:
 - 0.16.2
 libprotobuf:
 - 4.25.3
-libxcb:
-- '1.15'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_arm64_GZ_CLI_NAME_VARIANTgzcompatnameffmpeg6.yaml
+++ b/.ci_support/osx_arm64_GZ_CLI_NAME_VARIANTgzcompatnameffmpeg6.yaml
@@ -50,8 +50,6 @@ libode:
 - 0.16.2
 libprotobuf:
 - 4.25.3
-libxcb:
-- '1.15'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_GZ_CLI_NAME_VARIANTgzcompatnameffmpeg7.yaml
+++ b/.ci_support/osx_arm64_GZ_CLI_NAME_VARIANTgzcompatnameffmpeg7.yaml
@@ -50,8 +50,6 @@ libode:
 - 0.16.2
 libprotobuf:
 - 4.25.3
-libxcb:
-- '1.15'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_GZ_CLI_NAME_VARIANTorignameffmpeg6.yaml
+++ b/.ci_support/osx_arm64_GZ_CLI_NAME_VARIANTorignameffmpeg6.yaml
@@ -50,8 +50,6 @@ libode:
 - 0.16.2
 libprotobuf:
 - 4.25.3
-libxcb:
-- '1.15'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_GZ_CLI_NAME_VARIANTorignameffmpeg7.yaml
+++ b/.ci_support/osx_arm64_GZ_CLI_NAME_VARIANTorignameffmpeg7.yaml
@@ -50,8 +50,6 @@ libode:
 - 0.16.2
 libprotobuf:
 - 4.25.3
-libxcb:
-- '1.15'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -67,3 +67,22 @@ done
 if [[ "${GZ_CLI_NAME_VARIANT}" == "origname" ]]; then
   cp $PREFIX/bin/gz $PREFIX/bin/gz11
 fi
+
+# Ensure that plugins are found as libraries linked by the linker
+# in macos, see
+# https://github.com/RoboStack/ros-noetic/issues/228
+# https://github.com/RoboStack/ros-noetic/issues/462
+# https://github.com/RoboStack/ros-humble/issues/185
+# We do not symlink all the libraries as they do not have Gazebo-specific
+# prefix, so we prefer to minimize the risk of clobbering, so we only symlink
+# the one used in https://github.com/ros-simulation/gazebo_ros_pkgs/blob/f9e1a4607842afa5888ef01de31cd64a1e3e297f/gazebo_plugins/CMakeLists.txt
+if [[ "${target_platform}" == osx-* ]]; then
+    ln -s $CONDA_PREFIX/lib/gazebo-11/plugins/libCameraPlugin.dylib $CONDA_PREFIX/lib/libCameraPlugin.dylib
+    ln -s $CONDA_PREFIX/lib/gazebo-11/plugins/libElevatorPlugin.dylib $CONDA_PREFIX/lib/libElevatorPlugin.dylib
+    ln -s $CONDA_PREFIX/lib/gazebo-11/plugins/libMultiCameraPlugin.dylib $CONDA_PREFIX/lib/libMultiCameraPlugin.dylib
+    ln -s $CONDA_PREFIX/lib/gazebo-11/plugins/libDepthCameraPlugin.dylib $CONDA_PREFIX/lib/libDepthCameraPlugin.dylib
+    ln -s $CONDA_PREFIX/lib/gazebo-11/plugins/libGpuRayPlugin.dylib $CONDA_PREFIX/lib/libGpuRayPlugin.dylib
+    ln -s $CONDA_PREFIX/lib/gazebo-11/plugins/libHarnessPlugin.dylib $CONDA_PREFIX/lib/libHarnessPlugin.dylib
+    ln -s $CONDA_PREFIX/lib/gazebo-11/plugins/libWheelSlipPlugin.dylib $CONDA_PREFIX/lib/libWheelSlipPlugin.dylib
+    ln -s $CONDA_PREFIX/lib/gazebo-11/plugins/libRayPlugin.dylib $CONDA_PREFIX/lib/libRayPlugin.dylib
+fi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -77,12 +77,12 @@ fi
 # prefix, so we prefer to minimize the risk of clobbering, so we only symlink
 # the one used in https://github.com/ros-simulation/gazebo_ros_pkgs/blob/f9e1a4607842afa5888ef01de31cd64a1e3e297f/gazebo_plugins/CMakeLists.txt
 if [[ "${target_platform}" == osx-* ]]; then
-    ln -s $CONDA_PREFIX/lib/gazebo-11/plugins/libCameraPlugin.dylib $CONDA_PREFIX/lib/libCameraPlugin.dylib
-    ln -s $CONDA_PREFIX/lib/gazebo-11/plugins/libElevatorPlugin.dylib $CONDA_PREFIX/lib/libElevatorPlugin.dylib
-    ln -s $CONDA_PREFIX/lib/gazebo-11/plugins/libMultiCameraPlugin.dylib $CONDA_PREFIX/lib/libMultiCameraPlugin.dylib
-    ln -s $CONDA_PREFIX/lib/gazebo-11/plugins/libDepthCameraPlugin.dylib $CONDA_PREFIX/lib/libDepthCameraPlugin.dylib
-    ln -s $CONDA_PREFIX/lib/gazebo-11/plugins/libGpuRayPlugin.dylib $CONDA_PREFIX/lib/libGpuRayPlugin.dylib
-    ln -s $CONDA_PREFIX/lib/gazebo-11/plugins/libHarnessPlugin.dylib $CONDA_PREFIX/lib/libHarnessPlugin.dylib
-    ln -s $CONDA_PREFIX/lib/gazebo-11/plugins/libWheelSlipPlugin.dylib $CONDA_PREFIX/lib/libWheelSlipPlugin.dylib
-    ln -s $CONDA_PREFIX/lib/gazebo-11/plugins/libRayPlugin.dylib $CONDA_PREFIX/lib/libRayPlugin.dylib
+    ln -s $PREFIX/lib/gazebo-11/plugins/libCameraPlugin.dylib $PREFIX/lib/libCameraPlugin.dylib
+    ln -s $PREFIX/lib/gazebo-11/plugins/libElevatorPlugin.dylib $PREFIX/lib/libElevatorPlugin.dylib
+    ln -s $PREFIX/lib/gazebo-11/plugins/libMultiCameraPlugin.dylib $PREFIX/lib/libMultiCameraPlugin.dylib
+    ln -s $PREFIX/lib/gazebo-11/plugins/libDepthCameraPlugin.dylib $PREFIX/lib/libDepthCameraPlugin.dylib
+    ln -s $PREFIX/lib/gazebo-11/plugins/libGpuRayPlugin.dylib $PREFIX/lib/libGpuRayPlugin.dylib
+    ln -s $PREFIX/lib/gazebo-11/plugins/libHarnessPlugin.dylib $PREFIX/lib/libHarnessPlugin.dylib
+    ln -s $PREFIX/lib/gazebo-11/plugins/libWheelSlipPlugin.dylib $PREFIX/lib/libWheelSlipPlugin.dylib
+    ln -s $PREFIX/lib/gazebo-11/plugins/libRayPlugin.dylib $PREFIX/lib/libRayPlugin.dylib
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "gazebo" %}
 {% set version = "11.14.0" %}
-{% set number = 13 %}
+{% set number = 14 %}
 
 {% if GZ_CLI_NAME_VARIANT == "origname" %}
 {% set number = number + 200 %}
@@ -158,6 +158,7 @@ test:
     - test -f $PREFIX/bin/gazebo    # [unix]
     - test -f $PREFIX/bin/gz  # [unix and GZ_CLI_NAME_VARIANT == "origname"]
     - test -f $PREFIX/bin/gz11  # [unix]
+    - test -f $PREFIX/lib/libCameraPlugin.dylib  # [osx]
     - gzserver --version | grep "Gazebo multi-robot simulator, version"  # [unix]
     - gzclient --version | grep "Gazebo multi-robot simulator, version"  # [unix]
     - gazebo --version | grep "Gazebo multi-robot simulator, version"  # [unix]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
