### PR TITLE
Bump build number to 15 and fix recipe style to make sure that bots update the build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "gazebo" %}
 {% set version = "11.14.0" %}
-{% set number = 14 %}
+{% set number = 15 %}
 
 {% if GZ_CLI_NAME_VARIANT == "origname" %}
 {% set number = number + 200 %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,9 @@
 {% set name = "gazebo" %}
 {% set version = "11.14.0" %}
-{% set number = 15 %}
+{% set build_number = 15 %}
 
 {% if GZ_CLI_NAME_VARIANT == "origname" %}
-{% set number = number + 200 %}
+{% set build_number = build_number + 200 %}
 {% endif %}
 
 package:
@@ -23,7 +23,7 @@ source:
       - ffmpeg_5_6_fix.patch
 
 build:
-  number: {{ number }}
+  number: {{ build_number }}
   run_exports:
     - {{ pin_subpackage('gazebo', max_pin='x') }}
   string: {{ GZ_CLI_NAME_VARIANT }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}


### PR DESCRIPTION
If the build number is set via a variable, the variable should be named either `build` or `build_number`, see https://github.com/regro/cf-scripts/blob/bc57282361ba7437a46ee7ddde0783b94f1c1bc8/conda_forge_tick/update_recipe/build_number.py#L5-L11  .

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
